### PR TITLE
feat : 아이디 중복 확인 API 구현

### DIFF
--- a/src/main/java/hackathon/soa/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/hackathon/soa/common/apiPayload/code/status/ErrorStatus.java
@@ -18,7 +18,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // 사용자 관련
-    ID_DUPLICATED(HttpStatus.CONFLICT, "AUTH4002", "중복된 아이디입니다."),
+    ID_DUPLICATED(HttpStatus.CONFLICT, "AUTH4001", "이미 사용중인 아이디입니다."),
     ;
 
 

--- a/src/main/java/hackathon/soa/domain/auth/AuthController.java
+++ b/src/main/java/hackathon/soa/domain/auth/AuthController.java
@@ -5,6 +5,7 @@ import hackathon.soa.domain.auth.dto.AuthRequestDTO;
 import hackathon.soa.domain.auth.dto.AuthResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,6 +25,24 @@ public class AuthController {
             @RequestBody @Valid AuthRequestDTO.SignupRequestDTO request
     ) {
         AuthResponseDTO.SignupResponseDTO result = authService.register(request);
+        return ApiResponse.onSuccess(result);
+    }
+
+
+
+    @GetMapping("/check")
+    @Operation(
+            summary = "아이디 중복 확인",
+            description = "회원가입 시 아이디 중복 여부를 확인합니다."
+    )
+    public ApiResponse<AuthResponseDTO.DuplicateCheckResponseDTO> checkDuplicate(
+            @RequestParam String appId
+    ) {
+        AuthRequestDTO.DuplicateCheckRequestDTO request = AuthRequestDTO.DuplicateCheckRequestDTO.builder()
+                .appId(appId)
+                .build();
+
+        AuthResponseDTO.DuplicateCheckResponseDTO result = authService.checkDuplicate(request);
         return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/hackathon/soa/domain/auth/AuthConverter.java
+++ b/src/main/java/hackathon/soa/domain/auth/AuthConverter.java
@@ -11,4 +11,11 @@ public class AuthConverter {
                 .build()
                 ;
     }
+
+    public static AuthResponseDTO.DuplicateCheckResponseDTO toDuplicateCheckResponseDTO(boolean isExists) {
+        return AuthResponseDTO.DuplicateCheckResponseDTO.builder()
+                .isAvailable(!isExists)
+                .message(isExists ? "이미 사용중인 아이디입니다." : "사용가능한 아이디입니다.")
+                .build();
+    }
 }

--- a/src/main/java/hackathon/soa/domain/auth/AuthService.java
+++ b/src/main/java/hackathon/soa/domain/auth/AuthService.java
@@ -39,4 +39,11 @@ public class AuthService {
         // 4) ResponseDTO 변환 Converter 작업
         return AuthConverter.toSignUpResponseDTO(savedMember);
     }
+
+    public AuthResponseDTO.DuplicateCheckResponseDTO checkDuplicate(AuthRequestDTO.DuplicateCheckRequestDTO request) {
+        // 1) 아이디 중복 체크
+        boolean isExists = memberRepository.existsByAppId(request.getAppId());
+
+        return AuthConverter.toDuplicateCheckResponseDTO(isExists);
+    }
 }

--- a/src/main/java/hackathon/soa/domain/auth/dto/AuthRequestDTO.java
+++ b/src/main/java/hackathon/soa/domain/auth/dto/AuthRequestDTO.java
@@ -51,4 +51,15 @@ public class AuthRequestDTO {
         @NotNull(message = "프로필 이미지는 필수입니다")
         private Integer profileImage;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DuplicateCheckRequestDTO {
+        @NotBlank(message = "아이디는 필수입니다")
+        @Size(min = 4, max = 20, message = "아이디는 4~20자 사이여야 합니다")
+        @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문자와 숫자만 가능합니다")
+        private String appId;
+    }
 }

--- a/src/main/java/hackathon/soa/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/hackathon/soa/domain/auth/dto/AuthResponseDTO.java
@@ -14,4 +14,13 @@ public class AuthResponseDTO {
         private Long userId;
         private String appId;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DuplicateCheckResponseDTO {
+        private Boolean isAvailable;
+        private String message;
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> #6


## 📝 작업 내용
> 회원가입 도중에 있는 아이디 중복 확인을 위한 별도의 API를 구현하였습니다.